### PR TITLE
Async connect when in async mode (useful for android)

### DIFF
--- a/src/java/org/xmlBlaster/client/XmlBlasterAccess.java
+++ b/src/java/org/xmlBlaster/client/XmlBlasterAccess.java
@@ -515,7 +515,7 @@ public /*final*/ class XmlBlasterAccess extends AbstractCallbackExtended
                }
                this.dispatchManager = new ClientDispatchManager(glob, this.msgErrorHandler,
                                        getSecurityPlugin(), this.clientQueue, this,
-                                       this.connectQos.getAddresses(forceCbAddressCreation), sn);
+                                       this.connectQos.getAddresses(forceCbAddressCreation), sn, !this.isTrySyncMode());
                // the above can call toDead() and the client may have called shutdown(): this.connectQos == null again
                if (this.dispatchManager.isDead())
                    throw new XmlBlasterException(glob, ErrorCode.COMMUNICATION_NOCONNECTION_DEAD, ME, "connect call failed, your toDead() code did shutdown?");

--- a/src/java/org/xmlBlaster/client/dispatch/ClientDispatchManager.java
+++ b/src/java/org/xmlBlaster/client/dispatch/ClientDispatchManager.java
@@ -77,6 +77,8 @@ public final class ClientDispatchManager implements I_DispatchManager
    private boolean isShutdown = false;
    private boolean isSyncMode = false;
    private boolean trySyncMode = false; // true: client side queue embedding, false: server side callback queue
+   /** Use case android: allow queue initialization with unstable/slow internet connection */
+   private final boolean forceAsyncConnect;
 
    private boolean inAliveTransition = false;
    private final Object ALIVE_TRANSITION_MONITOR = new Object();
@@ -100,7 +102,7 @@ public final class ClientDispatchManager implements I_DispatchManager
    public ClientDispatchManager(Global glob, I_MsgErrorHandler failureListener,
                           I_MsgSecurityInterceptor securityInterceptor,
                           I_Queue msgQueue, I_ConnectionStatusListener connectionStatusListener,
-                          AddressBase[] addrArr, SessionName sessionName) throws XmlBlasterException {
+                          AddressBase[] addrArr, SessionName sessionName, boolean forceAsyncConnect) throws XmlBlasterException {
       if (failureListener == null || msgQueue == null)
          throw new IllegalArgumentException("DispatchManager failureListener=" + failureListener + " msgQueue=" + msgQueue);
       this.inDispatchManagerCtor = true;
@@ -108,6 +110,7 @@ public final class ClientDispatchManager implements I_DispatchManager
       this.glob = glob;
 
       this.sessionName = sessionName;
+      this.forceAsyncConnect = forceAsyncConnect;
 
       if (log.isLoggable(Level.FINE)) log.fine(ME+": Loading DispatchManager ...");
 
@@ -138,7 +141,7 @@ public final class ClientDispatchManager implements I_DispatchManager
       }
 
       this.msgQueue.addPutListener(this); // to get putPre() and putPost() events
-
+      
       this.dispatchConnectionsHandler.initialize(addrArr);
       this.inDispatchManagerCtor = false;
    }
@@ -152,6 +155,11 @@ public final class ClientDispatchManager implements I_DispatchManager
 
    public boolean isSyncMode() {
       return this.isSyncMode;
+   }
+   
+   @Override
+   public boolean isForceAsyncConnect() {
+      return forceAsyncConnect;
    }
 
    /**

--- a/src/java/org/xmlBlaster/engine/dispatch/ServerDispatchManager.java
+++ b/src/java/org/xmlBlaster/engine/dispatch/ServerDispatchManager.java
@@ -164,6 +164,10 @@ public final class ServerDispatchManager implements I_DispatchManager
    public boolean isSyncMode() {
       return this.isSyncMode;
    }
+   
+   public boolean isForceAsyncConnect() {
+      return false;
+   }
 
    /**
     * Set behavior of dispatch framework.

--- a/src/java/org/xmlBlaster/util/Global.java
+++ b/src/java/org/xmlBlaster/util/Global.java
@@ -1401,6 +1401,9 @@ public class Global implements Cloneable
                this.ip_addr = java.net.InetAddress.getLocalHost().getHostAddress(); // e.g. "204.120.1.12"
             } catch (java.net.UnknownHostException e) {
                log.warning("Can't determine local IP address, try e.g. '-bootstrapHostname 192.168.10.1' on command line: " + e.toString());
+            } catch (Throwable e) {
+               // NetworkOnMainThread exception on android
+               log.warning("Can't determine local IP address, try e.g. '-bootstrapHostname 192.168.10.1' on command line: " + e.toString());
             }
             if (this.ip_addr == null) this.ip_addr = "127.0.0.1";
          }

--- a/src/java/org/xmlBlaster/util/dispatch/DispatchConnection.java
+++ b/src/java/org/xmlBlaster/util/dispatch/DispatchConnection.java
@@ -134,6 +134,9 @@ abstract public class DispatchConnection implements I_Timeout
          logInterval = (int)(this.logEveryMillis / address.getDelay());
 
       try {
+         if (connectionsHandler.dispatchManager.isForceAsyncConnect()) {
+            throw new XmlBlasterException(glob, ErrorCode.COMMUNICATION, "Forcing async connect initially");
+         }
          connectLowlevel();
          handleTransition(true, null);
       }

--- a/src/java/org/xmlBlaster/util/dispatch/I_DispatchManager.java
+++ b/src/java/org/xmlBlaster/util/dispatch/I_DispatchManager.java
@@ -37,7 +37,9 @@ public interface I_DispatchManager extends I_Timeout, I_QueuePutListener {
     */
    SessionName getSessionName();
 
-    boolean isSyncMode();
+   boolean isSyncMode();
+   
+   boolean isForceAsyncConnect();
 
    /**
     * Set behavior of dispatch framework.


### PR DESCRIPTION
When in Async mode, we shouldn't call socket connect synchronously.
This will omit the socket connect call and instead connects as polling and lets the worker thread connect.
Advantage: we can also connect when we don't have an internet connection, xmlBlaster will handle the connecting when possible.
Queues are initialized even without internet.