### PR TITLE
bugfix: dispatch defaultPlugin is not respected

### DIFF
--- a/src/java/org/xmlBlaster/engine/dispatch/ServerDispatchManager.java
+++ b/src/java/org/xmlBlaster/engine/dispatch/ServerDispatchManager.java
@@ -137,8 +137,8 @@ public final class ServerDispatchManager implements I_DispatchManager
        * and if none is found one is created (see DispatcherPluginManager)
        * Default server setting is to use no dispatcher plugin
        */
-      PropString propString = new PropString(PluginManagerBase.NO_PLUGIN_TYPE); // "undef";
-      if (addrArr != null && addrArr.length > 0) // Check if client wishes a specific plugin
+      PropString propString = new PropString(glob.getProperty().get("DispatchPlugin/defaultPlugin", PluginManagerBase.NO_PLUGIN_TYPE));
+      if (addrArr != null && addrArr.length > 0 && !PluginManagerBase.NO_PLUGIN_TYPE.equals(addrArr[0].getDispatchPlugin())) // Check if client wishes a specific plugin
          propString.setValue(addrArr[0].getDispatchPlugin());
       this.typeVersion = propString.getValue();
       this.msgInterceptor = glob.getDispatchPluginManager().getPlugin(this.typeVersion); // usually from cache


### PR DESCRIPTION
@mlaghi please review:
xmlBlaster config "DispatchPlugin/defaultPlugin" does not seem to be respected currently, always defaults to "undef".
Is this the correct way to fix it?